### PR TITLE
Address issue #2

### DIFF
--- a/src/bf.c
+++ b/src/bf.c
@@ -8,7 +8,7 @@
 char * interpret(char *program) {
 	unsigned char tape[30000];
 	unsigned char* ptr = tape;
-	char * output;
+	char * output = calloc(1, 10000);
 	size_t i;
 	size_t loop;
 	for (i=0;program[i] != 0;i++) {
@@ -26,7 +26,7 @@ char * interpret(char *program) {
 			--*ptr;
 		}
 		if (c=='.') {
-			strcat(output,*ptr);
+			strncat(output, ptr, 1);
 		}
 		if (c=='[' && !(*ptr)) {
 			while (program[i]!=']') {


### PR DESCRIPTION
Allocates a buffer for output and initializes it to 0. Change the appending method to use strncat of length 1 which should provide similar results while ensuring we pass in valid input.

Have not tested